### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/k22036/syllabus-api-nextjs/security/code-scanning/1](https://github.com/k22036/syllabus-api-nextjs/security/code-scanning/1)

To fix the problem, explicitly declare restricted `GITHUB_TOKEN` permissions in the workflow. Since this CI job only needs to read the repository code (for checkout, type-check, lint, build, and tests), it is sufficient to set `contents: read`. This can be done either at the root level (applies to all jobs) or under the `build` job. The best fix with minimal behavioral change is to add a top-level `permissions` block with `contents: read`, which documents the intent and restricts token capabilities for all current and future jobs in this workflow.

Concretely, in `.github/workflows/ci.yml`, insert a `permissions:` section after the `on:` block and before `jobs:`. No imports or additional methods are required; this is purely a YAML configuration change. The rest of the workflow steps remain unchanged, and `actions/checkout` will still work with `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDワークフローのセキュリティ設定を更新しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->