### PR TITLE
feat(api): implement ETag support

### DIFF
--- a/app/api/fetch_syllabus/route.ts
+++ b/app/api/fetch_syllabus/route.ts
@@ -1,11 +1,26 @@
+import { createHash } from "node:crypto";
 import data from "../../data/shaped_data.json";
 
-export async function GET() {
-  return new Response(JSON.stringify(data), {
+const serialized = JSON.stringify(data);
+const etag = `"${createHash("sha256").update(serialized).digest("hex").slice(0, 16)}"`;
+
+export async function GET(request: Request) {
+  const ifNoneMatch = request.headers.get("if-none-match");
+  if (ifNoneMatch === etag) {
+    return new Response(null, {
+      status: 304,
+      headers: {
+        "cache-control": "public, max-age=60, stale-while-revalidate=300",
+      },
+    });
+  }
+
+  return new Response(serialized, {
     status: 200,
     headers: {
       "content-type": "application/json; charset=UTF-8",
       "cache-control": "public, max-age=60, stale-while-revalidate=300",
+      etag: etag,
     },
   });
 }

--- a/tests/api/fetch_syllabus.test.ts
+++ b/tests/api/fetch_syllabus.test.ts
@@ -14,17 +14,19 @@ const SyllabusItemSchema = z.object({
 const ResponseSchema = z.record(z.string(), z.array(SyllabusItemSchema));
 
 const BASE_URL = "http://localhost/api/fetch_syllabus";
+const createRequest = (headers?: HeadersInit): Request =>
+  new Request(BASE_URL, { headers });
 
 describe("GET /api/fetch_syllabus", () => {
   describe("初回リクエスト（If-None-Match なし）", () => {
     test("ステータスコードが 200 であること", async () => {
-      const request = new Request(BASE_URL);
+      const request = createRequest();
       const response = await GET(request);
       expect(response.status).toBe(200);
     });
 
     test("ETag ヘッダーが存在すること", async () => {
-      const request = new Request(BASE_URL);
+      const request = createRequest();
       const response = await GET(request);
       const etag = response.headers.get("etag");
       expect(etag).not.toBeNull();
@@ -33,7 +35,7 @@ describe("GET /api/fetch_syllabus", () => {
     });
 
     test("Cache-Control ヘッダーが設定されていること", async () => {
-      const request = new Request(BASE_URL);
+      const request = createRequest();
       const response = await GET(request);
       const cacheControl = response.headers.get("cache-control");
       expect(cacheControl).not.toBeNull();
@@ -43,7 +45,7 @@ describe("GET /api/fetch_syllabus", () => {
     });
 
     test("Content-Type が application/json であること", async () => {
-      const request = new Request(BASE_URL);
+      const request = createRequest();
       const response = await GET(request);
       expect(response.headers.get("content-type")).toContain(
         "application/json",
@@ -51,7 +53,7 @@ describe("GET /api/fetch_syllabus", () => {
     });
 
     test("レスポンスボディがスキーマに準拠していること", async () => {
-      const request = new Request(BASE_URL);
+      const request = createRequest();
       const response = await GET(request);
       const data = await response.json();
       const result = ResponseSchema.safeParse(data);
@@ -64,7 +66,7 @@ describe("GET /api/fetch_syllabus", () => {
     });
 
     test("レスポンスデータが空でないこと", async () => {
-      const request = new Request(BASE_URL);
+      const request = createRequest();
       const response = await GET(request);
       const data = await response.json();
       expect(Object.keys(data).length).toBeGreaterThan(0);
@@ -74,14 +76,14 @@ describe("GET /api/fetch_syllabus", () => {
   describe("条件付きリクエスト（If-None-Match あり）", () => {
     test("ETag が一致する場合、304 を返しボディが空であること", async () => {
       // まず通常リクエストで ETag を取得する
-      const firstRequest = new Request(BASE_URL);
+      const firstRequest = createRequest();
       const firstResponse = await GET(firstRequest);
       const etag = firstResponse.headers.get("etag");
       expect(etag).not.toBeNull();
 
       // 取得した ETag を If-None-Match に付けて再リクエスト
-      const conditionalRequest = new Request(BASE_URL, {
-        headers: { "if-none-match": etag as string },
+      const conditionalRequest = createRequest({
+        "if-none-match": etag as string,
       });
       const conditionalResponse = await GET(conditionalRequest);
 
@@ -93,13 +95,11 @@ describe("GET /api/fetch_syllabus", () => {
     });
 
     test("ETag が一致する場合、304 レスポンスにも Cache-Control ヘッダーが存在すること", async () => {
-      const firstRequest = new Request(BASE_URL);
+      const firstRequest = createRequest();
       const firstResponse = await GET(firstRequest);
       const etag = firstResponse.headers.get("etag") as string;
 
-      const conditionalRequest = new Request(BASE_URL, {
-        headers: { "if-none-match": etag },
-      });
+      const conditionalRequest = createRequest({ "if-none-match": etag });
       const conditionalResponse = await GET(conditionalRequest);
 
       expect(conditionalResponse.status).toBe(304);
@@ -108,9 +108,7 @@ describe("GET /api/fetch_syllabus", () => {
 
     test("ETag が一致しない場合、200 を返しボディが存在すること", async () => {
       const staleEtag = '"0000000000000000"';
-      const request = new Request(BASE_URL, {
-        headers: { "if-none-match": staleEtag },
-      });
+      const request = createRequest({ "if-none-match": staleEtag });
       const response = await GET(request);
 
       expect(response.status).toBe(200);
@@ -121,9 +119,7 @@ describe("GET /api/fetch_syllabus", () => {
 
     test("ETag が一致しない場合、新しい ETag ヘッダーが付いていること", async () => {
       const staleEtag = '"0000000000000000"';
-      const request = new Request(BASE_URL, {
-        headers: { "if-none-match": staleEtag },
-      });
+      const request = createRequest({ "if-none-match": staleEtag });
       const response = await GET(request);
 
       expect(response.status).toBe(200);
@@ -133,11 +129,11 @@ describe("GET /api/fetch_syllabus", () => {
     });
 
     test("同一エンドポイントへの複数回リクエストで ETag が変わらないこと", async () => {
-      const firstRequest = new Request(BASE_URL);
+      const firstRequest = createRequest();
       const firstResponse = await GET(firstRequest);
       const firstEtag = firstResponse.headers.get("etag");
 
-      const secondRequest = new Request(BASE_URL);
+      const secondRequest = createRequest();
       const secondResponse = await GET(secondRequest);
       const secondEtag = secondResponse.headers.get("etag");
 

--- a/tests/api/fetch_syllabus.test.ts
+++ b/tests/api/fetch_syllabus.test.ts
@@ -13,21 +13,135 @@ const SyllabusItemSchema = z.object({
 // レスポンス全体のスキーマ（キーが文字列、値がSyllabusItemの配列）
 const ResponseSchema = z.record(z.string(), z.array(SyllabusItemSchema));
 
+const BASE_URL = "http://localhost/api/fetch_syllabus";
+
 describe("GET /api/fetch_syllabus", () => {
-  test("should validate response against schema", async () => {
-    const response = await GET();
-    expect(response.status).toBe(200);
+  describe("初回リクエスト（If-None-Match なし）", () => {
+    test("ステータスコードが 200 であること", async () => {
+      const request = new Request(BASE_URL);
+      const response = await GET(request);
+      expect(response.status).toBe(200);
+    });
 
-    const data = await response.json();
-    const result = ResponseSchema.safeParse(data);
+    test("ETag ヘッダーが存在すること", async () => {
+      const request = new Request(BASE_URL);
+      const response = await GET(request);
+      const etag = response.headers.get("etag");
+      expect(etag).not.toBeNull();
+      // ETag は ダブルクォートで囲まれた文字列
+      expect(etag).toMatch(/^".+"$/);
+    });
 
-    // パース失敗時はエラー詳細を表示してテストを落とす
-    if (!result.success) {
-      console.error(result.error);
-    }
-    expect(result.success).toBe(true);
+    test("Cache-Control ヘッダーが設定されていること", async () => {
+      const request = new Request(BASE_URL);
+      const response = await GET(request);
+      const cacheControl = response.headers.get("cache-control");
+      expect(cacheControl).not.toBeNull();
+      expect(cacheControl).toContain("public");
+      expect(cacheControl).toContain("max-age=");
+      expect(cacheControl).toContain("stale-while-revalidate=");
+    });
 
-    // データが空でないことも確認
-    expect(Object.keys(data).length).toBeGreaterThan(0);
+    test("Content-Type が application/json であること", async () => {
+      const request = new Request(BASE_URL);
+      const response = await GET(request);
+      expect(response.headers.get("content-type")).toContain(
+        "application/json",
+      );
+    });
+
+    test("レスポンスボディがスキーマに準拠していること", async () => {
+      const request = new Request(BASE_URL);
+      const response = await GET(request);
+      const data = await response.json();
+      const result = ResponseSchema.safeParse(data);
+
+      // パース失敗時はエラー詳細を表示してテストを落とす
+      if (!result.success) {
+        console.error(result.error);
+      }
+      expect(result.success).toBe(true);
+    });
+
+    test("レスポンスデータが空でないこと", async () => {
+      const request = new Request(BASE_URL);
+      const response = await GET(request);
+      const data = await response.json();
+      expect(Object.keys(data).length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("条件付きリクエスト（If-None-Match あり）", () => {
+    test("ETag が一致する場合、304 を返しボディが空であること", async () => {
+      // まず通常リクエストで ETag を取得する
+      const firstRequest = new Request(BASE_URL);
+      const firstResponse = await GET(firstRequest);
+      const etag = firstResponse.headers.get("etag");
+      expect(etag).not.toBeNull();
+
+      // 取得した ETag を If-None-Match に付けて再リクエスト
+      const conditionalRequest = new Request(BASE_URL, {
+        headers: { "if-none-match": etag as string },
+      });
+      const conditionalResponse = await GET(conditionalRequest);
+
+      expect(conditionalResponse.status).toBe(304);
+
+      // 304 はボディを持たない
+      const body = await conditionalResponse.text();
+      expect(body).toBe("");
+    });
+
+    test("ETag が一致する場合、304 レスポンスにも Cache-Control ヘッダーが存在すること", async () => {
+      const firstRequest = new Request(BASE_URL);
+      const firstResponse = await GET(firstRequest);
+      const etag = firstResponse.headers.get("etag") as string;
+
+      const conditionalRequest = new Request(BASE_URL, {
+        headers: { "if-none-match": etag },
+      });
+      const conditionalResponse = await GET(conditionalRequest);
+
+      expect(conditionalResponse.status).toBe(304);
+      expect(conditionalResponse.headers.get("cache-control")).not.toBeNull();
+    });
+
+    test("ETag が一致しない場合、200 を返しボディが存在すること", async () => {
+      const staleEtag = '"0000000000000000"';
+      const request = new Request(BASE_URL, {
+        headers: { "if-none-match": staleEtag },
+      });
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(Object.keys(data).length).toBeGreaterThan(0);
+    });
+
+    test("ETag が一致しない場合、新しい ETag ヘッダーが付いていること", async () => {
+      const staleEtag = '"0000000000000000"';
+      const request = new Request(BASE_URL, {
+        headers: { "if-none-match": staleEtag },
+      });
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const newEtag = response.headers.get("etag");
+      expect(newEtag).not.toBeNull();
+      expect(newEtag).not.toBe(staleEtag);
+    });
+
+    test("同一エンドポイントへの複数回リクエストで ETag が変わらないこと", async () => {
+      const firstRequest = new Request(BASE_URL);
+      const firstResponse = await GET(firstRequest);
+      const firstEtag = firstResponse.headers.get("etag");
+
+      const secondRequest = new Request(BASE_URL);
+      const secondResponse = await GET(secondRequest);
+      const secondEtag = secondResponse.headers.get("etag");
+
+      expect(firstEtag).toBe(secondEtag);
+    });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * シラバス取得APIに条件付きリクエスト対応とETagベースの検証を導入しました。変更がない場合は304を返し、不要な本文送信を省略して帯域を節約します。レスポンスに適切なCache-ControlとETagを含めます。

* **テスト**
  * キャッシュ挙動、条件付きリクエスト（If-None-Match）処理、Content-Type、ETagの安定性および非空データを検証するテストを拡張しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->