### PR TITLE
Add query-based filtering to fetch_syllabus endpoint

### DIFF
--- a/app/_components/ApiExplorer.tsx
+++ b/app/_components/ApiExplorer.tsx
@@ -3,6 +3,7 @@
 import { useReducer } from "react";
 import {
   REQUEST_HEADERS_DOCS,
+  REQUEST_QUERY_DOCS,
   RESPONSE_HEADERS_DOCS,
 } from "../api/fetch_syllabus/constants";
 
@@ -70,6 +71,10 @@ type ApiExplorerState = {
   loading: boolean;
   responseData: ResponseData | null;
   error: string | null;
+  subject: string;
+  room: string;
+  season: string;
+  open_time: string;
 };
 
 type ApiExplorerAction =
@@ -80,7 +85,8 @@ type ApiExplorerAction =
       type: "FETCH_SUCCESS";
       payload: { responseData: ResponseData; etag: string | null };
     }
-  | { type: "FETCH_ERROR"; payload: string };
+  | { type: "FETCH_ERROR"; payload: string }
+  | { type: "SET_QUERY_PARAM"; payload: { name: string; value: string } };
 
 function apiExplorerReducer(
   state: ApiExplorerState,
@@ -103,6 +109,8 @@ function apiExplorerReducer(
       };
     case "FETCH_ERROR":
       return { ...state, loading: false, error: action.payload };
+    case "SET_QUERY_PARAM":
+      return { ...state, [action.payload.name]: action.payload.value };
     default:
       return state;
   }
@@ -116,9 +124,24 @@ export default function ApiExplorer() {
     loading: false,
     responseData: null,
     error: null,
+    subject: "",
+    room: "",
+    season: "",
+    open_time: "",
   });
 
-  const { isOpen, useEtag, storedEtag, loading, responseData, error } = state;
+  const {
+    isOpen,
+    useEtag,
+    storedEtag,
+    loading,
+    responseData,
+    error,
+    subject,
+    room,
+    season,
+    open_time,
+  } = state;
 
   async function sendRequest(): Promise<void> {
     dispatch({ type: "FETCH_START" });
@@ -130,7 +153,14 @@ export default function ApiExplorer() {
 
     const start = performance.now();
     try {
-      const res = await fetch("/api/fetch_syllabus", { headers });
+      const params = new URLSearchParams();
+      if (subject.trim()) params.append("subject", subject.trim());
+      if (room.trim()) params.append("room", room.trim());
+      if (season.trim()) params.append("season", season.trim());
+      if (open_time.trim()) params.append("open_time", open_time.trim());
+
+      const queryString = params.toString() ? `?${params.toString()}` : "";
+      const res = await fetch(`/api/fetch_syllabus${queryString}`, { headers });
       const duration = Math.round(performance.now() - start);
 
       const responseHeaders: Record<string, string> = {};
@@ -189,7 +219,40 @@ export default function ApiExplorer() {
 
       {/* ── Documentation grid ──────────────────────────────────────── */}
       <div className="bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 py-4">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+          {/* Query Parameters */}
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+              Query Parameters
+            </h3>
+            <table className="w-full text-xs border-separate border-spacing-0">
+              <thead>
+                <tr className="text-left text-gray-500 dark:text-gray-400">
+                  <th className="pb-1 pr-3 font-medium">Name</th>
+                  <th className="pb-1 pr-3 font-medium">Type</th>
+                  <th className="pb-1 font-medium">Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                {REQUEST_QUERY_DOCS.map((h) => (
+                  <tr key={h.name} className="align-top">
+                    <td className="py-1 pr-3">
+                      <code className="font-mono text-emerald-700 dark:text-emerald-400 whitespace-nowrap">
+                        {h.name}
+                      </code>
+                    </td>
+                    <td className="py-1 pr-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                      {h.type}
+                    </td>
+                    <td className="py-1 text-gray-600 dark:text-gray-300">
+                      {h.description}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
           {/* Request Headers */}
           <div>
             <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
@@ -261,6 +324,34 @@ export default function ApiExplorer() {
       {/* ── Try it panel ────────────────────────────────────────────── */}
       {isOpen && (
         <div className="bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 px-4 py-4 space-y-4">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 pb-4 border-b border-gray-100 dark:border-gray-800">
+            {(["subject", "room", "season", "open_time"] as const).map(
+              (param) => (
+                <div key={param} className="space-y-1">
+                  <label
+                    htmlFor={`query-${param}`}
+                    className="text-xs font-medium text-gray-600 dark:text-gray-400 block pb-1"
+                  >
+                    {param}
+                  </label>
+                  <input
+                    id={`query-${param}`}
+                    type="text"
+                    value={state[param]}
+                    onChange={(e) =>
+                      dispatch({
+                        type: "SET_QUERY_PARAM",
+                        payload: { name: param, value: e.target.value },
+                      })
+                    }
+                    className="block w-full rounded border border-gray-300 bg-white text-sm dark:bg-gray-800 dark:border-gray-600 dark:text-gray-200 py-1.5 px-2 outline-none focus:ring-2 focus:border-emerald-500 focus:ring-emerald-500/20"
+                    placeholder={`...`}
+                  />
+                </div>
+              ),
+            )}
+          </div>
+
           {/* Controls row */}
           <div className="flex flex-wrap items-center gap-4">
             <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 select-none cursor-pointer">

--- a/app/_components/ApiExplorer.tsx
+++ b/app/_components/ApiExplorer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useReducer, useState } from "react";
+import { formatJsonBody, getStatusBadgeClass } from "../_utils/formatters";
 import {
   REQUEST_HEADERS_DOCS,
   REQUEST_QUERY_DOCS,
@@ -13,32 +14,6 @@ type ResponseData = {
   body: string;
   duration: number;
 };
-
-function formatBody(raw: string): string {
-  try {
-    const parsed = JSON.parse(raw) as Record<string, unknown[]>;
-    const keys = Object.keys(parsed);
-    const total = keys.length;
-    const previewKeys = keys.slice(0, 3);
-    const preview: Record<string, unknown[]> = {};
-    for (const key of previewKeys) {
-      preview[key] = parsed[key];
-    }
-    return `// Showing ${Math.min(3, total)} of ${total} rooms\n${JSON.stringify(preview, null, 2)}`;
-  } catch {
-    return raw;
-  }
-}
-
-function statusBadgeClass(status: number): string {
-  if (status >= 200 && status < 300) {
-    return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200";
-  }
-  if (status >= 300 && status < 400) {
-    return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
-  }
-  return "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200";
-}
 
 type CollapsibleSectionProps = {
   title: string;
@@ -407,7 +382,7 @@ export default function ApiExplorer() {
               {/* Status + duration */}
               <div className="flex items-center gap-3">
                 <span
-                  className={`px-2 py-0.5 rounded text-xs font-bold ${statusBadgeClass(responseData.status)}`}
+                  className={`px-2 py-0.5 rounded text-xs font-bold ${getStatusBadgeClass(responseData.status)}`}
                 >
                   {responseData.status}
                 </span>
@@ -441,7 +416,7 @@ export default function ApiExplorer() {
               ) : (
                 <CollapsibleSection title="Response Body" defaultOpen>
                   <pre className="mt-2 bg-gray-50 dark:bg-gray-800 p-3 text-xs overflow-auto max-h-64 rounded">
-                    {formatBody(responseData.body)}
+                    {formatJsonBody(responseData.body)}
                   </pre>
                 </CollapsibleSection>
               )}

--- a/app/_components/ApiExplorer.tsx
+++ b/app/_components/ApiExplorer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useReducer } from "react";
+import { useReducer, useState } from "react";
 import {
   REQUEST_HEADERS_DOCS,
   REQUEST_QUERY_DOCS,
@@ -64,6 +64,63 @@ function CollapsibleSection({
   );
 }
 
+type DocTableItem = {
+  name: string;
+  type?: string;
+  value?: string;
+  description: string;
+};
+
+type DocTableProps = {
+  title: string;
+  items: DocTableItem[];
+  valueLabel?: string;
+  nameColorClass?: string;
+};
+
+function DocTable({
+  title,
+  items,
+  valueLabel = "Type",
+  nameColorClass = "text-emerald-700 dark:text-emerald-400",
+}: DocTableProps) {
+  return (
+    <div>
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
+        {title}
+      </h3>
+      <table className="w-full text-xs border-separate border-spacing-0">
+        <thead>
+          <tr className="text-left text-gray-500 dark:text-gray-400">
+            <th className="pb-1 pr-3 font-medium">Name</th>
+            <th className="pb-1 pr-3 font-medium">{valueLabel}</th>
+            <th className="pb-1 font-medium">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((h) => (
+            <tr key={h.name} className="align-top">
+              <td className="py-1 pr-3">
+                <code
+                  className={`font-mono whitespace-nowrap ${nameColorClass}`}
+                >
+                  {h.name}
+                </code>
+              </td>
+              <td className="py-1 pr-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
+                {h.type || h.value}
+              </td>
+              <td className="py-1 text-gray-600 dark:text-gray-300">
+                {h.description}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
 type ApiExplorerState = {
   isOpen: boolean;
   useEtag: boolean;
@@ -117,6 +174,7 @@ function apiExplorerReducer(
 }
 
 export default function ApiExplorer() {
+  const [copied, setCopied] = useState(false);
   const [state, dispatch] = useReducer(apiExplorerReducer, {
     isOpen: false,
     useEtag: false,
@@ -143,6 +201,17 @@ export default function ApiExplorer() {
     open_time,
   } = state;
 
+  const currentParams = new URLSearchParams();
+  if (subject.trim()) currentParams.append("subject", subject.trim());
+  if (room.trim()) currentParams.append("room", room.trim());
+  if (season.trim()) currentParams.append("season", season.trim());
+  if (open_time.trim()) currentParams.append("open_time", open_time.trim());
+
+  const currentQueryString = currentParams.toString()
+    ? `?${currentParams.toString()}`
+    : "";
+  const requestUrl = `/api/fetch_syllabus${currentQueryString}`;
+
   async function sendRequest(): Promise<void> {
     dispatch({ type: "FETCH_START" });
 
@@ -153,14 +222,7 @@ export default function ApiExplorer() {
 
     const start = performance.now();
     try {
-      const params = new URLSearchParams();
-      if (subject.trim()) params.append("subject", subject.trim());
-      if (room.trim()) params.append("room", room.trim());
-      if (season.trim()) params.append("season", season.trim());
-      if (open_time.trim()) params.append("open_time", open_time.trim());
-
-      const queryString = params.toString() ? `?${params.toString()}` : "";
-      const res = await fetch(`/api/fetch_syllabus${queryString}`, { headers });
+      const res = await fetch(requestUrl, { headers });
       const duration = Math.round(performance.now() - start);
 
       const responseHeaders: Record<string, string> = {};
@@ -220,104 +282,14 @@ export default function ApiExplorer() {
       {/* ── Documentation grid ──────────────────────────────────────── */}
       <div className="bg-gray-50 dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-4 py-4">
         <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
-          {/* Query Parameters */}
-          <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
-              Query Parameters
-            </h3>
-            <table className="w-full text-xs border-separate border-spacing-0">
-              <thead>
-                <tr className="text-left text-gray-500 dark:text-gray-400">
-                  <th className="pb-1 pr-3 font-medium">Name</th>
-                  <th className="pb-1 pr-3 font-medium">Type</th>
-                  <th className="pb-1 font-medium">Description</th>
-                </tr>
-              </thead>
-              <tbody>
-                {REQUEST_QUERY_DOCS.map((h) => (
-                  <tr key={h.name} className="align-top">
-                    <td className="py-1 pr-3">
-                      <code className="font-mono text-emerald-700 dark:text-emerald-400 whitespace-nowrap">
-                        {h.name}
-                      </code>
-                    </td>
-                    <td className="py-1 pr-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                      {h.type}
-                    </td>
-                    <td className="py-1 text-gray-600 dark:text-gray-300">
-                      {h.description}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Request Headers */}
-          <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
-              Request Headers
-            </h3>
-            <table className="w-full text-xs border-separate border-spacing-0">
-              <thead>
-                <tr className="text-left text-gray-500 dark:text-gray-400">
-                  <th className="pb-1 pr-3 font-medium">Name</th>
-                  <th className="pb-1 pr-3 font-medium">Type</th>
-                  <th className="pb-1 font-medium">Description</th>
-                </tr>
-              </thead>
-              <tbody>
-                {REQUEST_HEADERS_DOCS.map((h) => (
-                  <tr key={h.name} className="align-top">
-                    <td className="py-1 pr-3">
-                      <code className="font-mono text-emerald-700 dark:text-emerald-400 whitespace-nowrap">
-                        {h.name}
-                      </code>
-                    </td>
-                    <td className="py-1 pr-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
-                      {h.type}
-                    </td>
-                    <td className="py-1 text-gray-600 dark:text-gray-300">
-                      {h.description}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Response Headers */}
-          <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 mb-2">
-              Response Headers
-            </h3>
-            <table className="w-full text-xs border-separate border-spacing-0">
-              <thead>
-                <tr className="text-left text-gray-500 dark:text-gray-400">
-                  <th className="pb-1 pr-3 font-medium">Name</th>
-                  <th className="pb-1 pr-3 font-medium">Value</th>
-                  <th className="pb-1 font-medium">Description</th>
-                </tr>
-              </thead>
-              <tbody>
-                {RESPONSE_HEADERS_DOCS.map((h) => (
-                  <tr key={h.name} className="align-top">
-                    <td className="py-1 pr-3">
-                      <code className="font-mono text-blue-700 dark:text-blue-400 whitespace-nowrap">
-                        {h.name}
-                      </code>
-                    </td>
-                    <td className="py-1 pr-3 text-gray-500 dark:text-gray-400">
-                      {h.value}
-                    </td>
-                    <td className="py-1 text-gray-600 dark:text-gray-300">
-                      {h.description}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+          <DocTable title="Query Parameters" items={REQUEST_QUERY_DOCS} />
+          <DocTable title="Request Headers" items={REQUEST_HEADERS_DOCS} />
+          <DocTable
+            title="Response Headers"
+            items={RESPONSE_HEADERS_DOCS}
+            valueLabel="Value"
+            nameColorClass="text-blue-700 dark:text-blue-400"
+          />
         </div>
       </div>
 
@@ -350,6 +322,38 @@ export default function ApiExplorer() {
                 </div>
               ),
             )}
+          </div>
+
+          {/* Current Request URL */}
+          <div className="flex items-start gap-3 text-sm bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 px-3 py-2 rounded-md">
+            <span className="text-gray-400 dark:text-gray-500 font-semibold select-none shrink-0 mt-0.5">
+              URL
+            </span>
+            <code
+              data-testid="request-url-preview"
+              className="font-mono text-gray-800 dark:text-gray-200 break-all flex-1 mt-0.5"
+            >
+              {requestUrl}
+            </code>
+            <button
+              type="button"
+              onClick={async () => {
+                try {
+                  const fullUrl =
+                    typeof window !== "undefined"
+                      ? window.location.origin + requestUrl
+                      : requestUrl;
+                  await navigator.clipboard.writeText(fullUrl);
+                  setCopied(true);
+                  setTimeout(() => setCopied(false), 2000);
+                } catch (e) {
+                  console.error("Failed to copy URL", e);
+                }
+              }}
+              className="shrink-0 ml-auto bg-white hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 px-2 py-1 rounded text-xs font-medium transition-colors cursor-pointer"
+            >
+              {copied ? "Copied!" : "Copy"}
+            </button>
           </div>
 
           {/* Controls row */}

--- a/app/_components/SyllabusDataBrowser.tsx
+++ b/app/_components/SyllabusDataBrowser.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 import type { SyllabusData } from "../_types/syllabus";
+import { parseSubject } from "../_utils/formatters";
 
 type Props = {
   data: SyllabusData;
@@ -10,18 +11,6 @@ type Props = {
 };
 
 const PAGE_SIZE = 20;
-
-function parseSubject(subject: string): { code: string; name: string } {
-  const sep = " : ";
-  const idx = subject.indexOf(sep);
-  if (idx === -1) {
-    return { code: "", name: subject };
-  }
-  return {
-    code: subject.slice(0, idx),
-    name: subject.slice(idx + sep.length),
-  };
-}
 
 const SEASONS = ["すべて", "前期", "後期"] as const;
 

--- a/app/_utils/formatters.ts
+++ b/app/_utils/formatters.ts
@@ -1,0 +1,41 @@
+export function parseSubject(subject: string): { code: string; name: string } {
+  const sep = " : ";
+  const idx = subject.indexOf(sep);
+  if (idx === -1) {
+    return { code: "", name: subject };
+  }
+  return {
+    code: subject.slice(0, idx),
+    name: subject.slice(idx + sep.length),
+  };
+}
+
+export function formatJsonBody(
+  raw: string,
+  maxKeys = 3,
+  entityName = "rooms",
+): string {
+  try {
+    const parsed = JSON.parse(raw) as Record<string, unknown[]>;
+    const keys = Object.keys(parsed);
+    const total = keys.length;
+    const previewKeys = keys.slice(0, maxKeys);
+    const preview: Record<string, unknown[]> = {};
+    for (const key of previewKeys) {
+      preview[key] = parsed[key];
+    }
+    return `// Showing ${Math.min(maxKeys, total)} of ${total} ${entityName}\n${JSON.stringify(preview, null, 2)}`;
+  } catch {
+    return raw;
+  }
+}
+
+export function getStatusBadgeClass(status: number): string {
+  if (status >= 200 && status < 300) {
+    return "bg-emerald-100 text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200";
+  }
+  if (status >= 300 && status < 400) {
+    return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
+  }
+  return "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200";
+}

--- a/app/api/fetch_syllabus/constants.ts
+++ b/app/api/fetch_syllabus/constants.ts
@@ -41,3 +41,30 @@ export const RESPONSE_HEADERS_DOCS: Array<{
     description: `${CACHE_AGE_SECONDS} 秒キャッシュし、最大 ${STALE_WHILE_REVALIDATE_SECONDS} 秒の古いレスポンス配信を許可。`,
   },
 ];
+
+export const REQUEST_QUERY_DOCS: Array<{
+  name: string;
+  type: string;
+  description: string;
+}> = [
+  {
+    name: "subject",
+    type: "string (optional)",
+    description: "講義名の部分一致検索（大文字・小文字を区別しません）。",
+  },
+  {
+    name: "room",
+    type: "string (optional)",
+    description: "教室名の部分一致検索（大文字・小文字を区別しません）。",
+  },
+  {
+    name: "season",
+    type: "string (optional)",
+    description: "開講学期の完全一致検索。",
+  },
+  {
+    name: "open_time",
+    type: "string (optional)",
+    description: "開講曜時限の完全一致検索。",
+  },
+];

--- a/app/api/fetch_syllabus/route.ts
+++ b/app/api/fetch_syllabus/route.ts
@@ -27,31 +27,23 @@ export async function GET(request: Request) {
   // フィルタリング条件が一つでも存在する場合はフィルタリング処理を行う
   if (subjectQuery || roomQuery || seasonQuery || openTimeQuery) {
     const filteredData: SyllabusData = {};
+
     for (const [roomName, items] of Object.entries(data)) {
-      const filteredItems = items.filter((item) => {
-        let isMatch = true;
-        if (
-          subjectQuery &&
-          !item.subject.toLowerCase().includes(subjectQuery)
-        ) {
-          isMatch = false;
-        }
-        if (roomQuery && !item.room.toLowerCase().includes(roomQuery)) {
-          isMatch = false;
-        }
-        if (seasonQuery && item.season !== seasonQuery) {
-          isMatch = false;
-        }
-        if (openTimeQuery && item.open_time !== openTimeQuery) {
-          isMatch = false;
-        }
-        return isMatch;
-      });
+      if (roomQuery && !roomName.toLowerCase().includes(roomQuery)) continue;
+
+      const filteredItems = items.filter(
+        (item) =>
+          (!subjectQuery ||
+            item.subject.toLowerCase().includes(subjectQuery)) &&
+          (!seasonQuery || item.season === seasonQuery) &&
+          (!openTimeQuery || item.open_time === openTimeQuery),
+      );
 
       if (filteredItems.length > 0) {
         filteredData[roomName] = filteredItems;
       }
     }
+
     filteredSerialized = JSON.stringify(filteredData);
     currentEtag = `"${createHash("sha256").update(filteredSerialized).digest("hex").slice(0, 16)}"`;
   }

--- a/app/api/fetch_syllabus/route.ts
+++ b/app/api/fetch_syllabus/route.ts
@@ -1,14 +1,15 @@
-import { createHash } from "node:crypto";
 import type { SyllabusData } from "../../_types/syllabus";
 import rawData from "../../data/shaped_data.json";
 import { SYLLABUS_HEADERS } from "./constants";
 import { syllabusQuerySchema } from "./schema";
+import { generateETag } from "./utils";
 
 const data = rawData as SyllabusData;
 
 // 事前にキャッシュしておくフルデータのシリアライズとETag
 const fullSerialized = JSON.stringify(data);
-const fullEtag = `"${createHash("sha256").update(fullSerialized).digest("hex").slice(0, 16)}"`;
+
+const fullEtag = generateETag(fullSerialized);
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -45,7 +46,7 @@ export async function GET(request: Request) {
     }
 
     filteredSerialized = JSON.stringify(filteredData);
-    currentEtag = `"${createHash("sha256").update(filteredSerialized).digest("hex").slice(0, 16)}"`;
+    currentEtag = generateETag(filteredSerialized);
   }
 
   const ifNoneMatch = request.headers.get("if-none-match");

--- a/app/api/fetch_syllabus/route.ts
+++ b/app/api/fetch_syllabus/route.ts
@@ -71,6 +71,7 @@ export async function GET(request: Request) {
       status: 304,
       headers: {
         "cache-control": SYLLABUS_HEADERS.cacheControl,
+        etag: currentEtag,
       },
     });
   }

--- a/app/api/fetch_syllabus/route.ts
+++ b/app/api/fetch_syllabus/route.ts
@@ -1,13 +1,61 @@
 import { createHash } from "node:crypto";
-import data from "../../data/shaped_data.json";
+import type { SyllabusData } from "../../_types/syllabus";
+import rawData from "../../data/shaped_data.json";
 import { SYLLABUS_HEADERS } from "./constants";
 
-const serialized = JSON.stringify(data);
-const etag = `"${createHash("sha256").update(serialized).digest("hex").slice(0, 16)}"`;
+const data = rawData as SyllabusData;
+
+// 事前にキャッシュしておくフルデータのシリアライズとETag
+const fullSerialized = JSON.stringify(data);
+const fullEtag = `"${createHash("sha256").update(fullSerialized).digest("hex").slice(0, 16)}"`;
 
 export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const searchParams = url.searchParams;
+
+  // フィルタリングパラメータの取得
+  const subjectQuery = searchParams.get("subject")?.toLowerCase() || null;
+  const roomQuery = searchParams.get("room")?.toLowerCase() || null;
+  const seasonQuery = searchParams.get("season") || null;
+  const openTimeQuery = searchParams.get("open_time") || null;
+
+  let filteredSerialized = fullSerialized;
+  let currentEtag = fullEtag;
+
+  // フィルタリング条件が一つでも存在する場合はフィルタリング処理を行う
+  if (subjectQuery || roomQuery || seasonQuery || openTimeQuery) {
+    const filteredData: SyllabusData = {};
+    for (const [roomName, items] of Object.entries(data)) {
+      const filteredItems = items.filter((item) => {
+        let isMatch = true;
+        if (
+          subjectQuery &&
+          !item.subject.toLowerCase().includes(subjectQuery)
+        ) {
+          isMatch = false;
+        }
+        if (roomQuery && !item.room.toLowerCase().includes(roomQuery)) {
+          isMatch = false;
+        }
+        if (seasonQuery && item.season !== seasonQuery) {
+          isMatch = false;
+        }
+        if (openTimeQuery && item.open_time !== openTimeQuery) {
+          isMatch = false;
+        }
+        return isMatch;
+      });
+
+      if (filteredItems.length > 0) {
+        filteredData[roomName] = filteredItems;
+      }
+    }
+    filteredSerialized = JSON.stringify(filteredData);
+    currentEtag = `"${createHash("sha256").update(filteredSerialized).digest("hex").slice(0, 16)}"`;
+  }
+
   const ifNoneMatch = request.headers.get("if-none-match");
-  if (ifNoneMatch === etag) {
+  if (ifNoneMatch === currentEtag) {
     return new Response(null, {
       status: 304,
       headers: {
@@ -16,12 +64,12 @@ export async function GET(request: Request) {
     });
   }
 
-  return new Response(serialized, {
+  return new Response(filteredSerialized, {
     status: 200,
     headers: {
       "content-type": SYLLABUS_HEADERS.contentType,
       "cache-control": SYLLABUS_HEADERS.cacheControl,
-      etag: etag,
+      etag: currentEtag,
     },
   });
 }

--- a/app/api/fetch_syllabus/route.ts
+++ b/app/api/fetch_syllabus/route.ts
@@ -1,3 +1,4 @@
+import z from "zod";
 import type { SyllabusData } from "../../_types/syllabus";
 import rawData from "../../data/shaped_data.json";
 import { SYLLABUS_HEADERS } from "./constants";
@@ -15,7 +16,22 @@ export async function GET(request: Request) {
   const url = new URL(request.url);
 
   // フィルタリングパラメータのパースと型変換（小文字化を含む）
-  const query = syllabusQuerySchema.parse(Object.fromEntries(url.searchParams));
+  const parsed = syllabusQuerySchema.safeParse(
+    Object.fromEntries(url.searchParams),
+  );
+  if (!parsed.success) {
+    return new Response(
+      JSON.stringify({
+        error: "Invalid query parameters",
+        details: z.treeifyError(parsed.error),
+      }),
+      {
+        status: 400,
+        headers: { "content-type": SYLLABUS_HEADERS.contentType },
+      },
+    );
+  }
+  const query = parsed.data;
 
   const subjectQuery = query.subject || null;
   const roomQuery = query.room || null;

--- a/app/api/fetch_syllabus/route.ts
+++ b/app/api/fetch_syllabus/route.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import type { SyllabusData } from "../../_types/syllabus";
 import rawData from "../../data/shaped_data.json";
 import { SYLLABUS_HEADERS } from "./constants";
+import { syllabusQuerySchema } from "./schema";
 
 const data = rawData as SyllabusData;
 
@@ -11,13 +12,14 @@ const fullEtag = `"${createHash("sha256").update(fullSerialized).digest("hex").s
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
-  const searchParams = url.searchParams;
 
-  // フィルタリングパラメータの取得
-  const subjectQuery = searchParams.get("subject")?.toLowerCase() || null;
-  const roomQuery = searchParams.get("room")?.toLowerCase() || null;
-  const seasonQuery = searchParams.get("season") || null;
-  const openTimeQuery = searchParams.get("open_time") || null;
+  // フィルタリングパラメータのパースと型変換（小文字化を含む）
+  const query = syllabusQuerySchema.parse(Object.fromEntries(url.searchParams));
+
+  const subjectQuery = query.subject || null;
+  const roomQuery = query.room || null;
+  const seasonQuery = query.season || null;
+  const openTimeQuery = query.open_time || null;
 
   let filteredSerialized = fullSerialized;
   let currentEtag = fullEtag;

--- a/app/api/fetch_syllabus/schema.ts
+++ b/app/api/fetch_syllabus/schema.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const syllabusQuerySchema = z.object({
+  subject: z
+    .string()
+    .transform((s) => s.toLowerCase())
+    .optional(),
+  room: z
+    .string()
+    .transform((s) => s.toLowerCase())
+    .optional(),
+  season: z.string().optional(),
+  open_time: z.string().optional(),
+});
+
+export type SyllabusQueryParams = z.infer<typeof syllabusQuerySchema>;

--- a/app/api/fetch_syllabus/utils.ts
+++ b/app/api/fetch_syllabus/utils.ts
@@ -1,0 +1,5 @@
+import { createHash } from "node:crypto";
+
+export function generateETag(payload: string): string {
+  return `"${createHash("sha256").update(payload).digest("hex").slice(0, 16)}"`;
+}

--- a/tests/api/fetch_syllabus.test.ts
+++ b/tests/api/fetch_syllabus.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { z } from "zod";
+import type { SyllabusData } from "../../app/_types/syllabus";
 import {
   RESPONSE_HEADERS_DOCS,
   SYLLABUS_HEADERS,
@@ -165,55 +166,47 @@ describe("GET /api/fetch_syllabus", () => {
   });
 
   describe("クエリパラメータによるフィルタリング", () => {
-    test("subject パラメータで部分一致フィルタリングができること", async () => {
-      const request = createRequest(undefined, { subject: "プログラミング" });
+    // リクエスト作成と型アサーション、配列の平坦化をまとめたヘルパー関数
+    async function fetchFilteredData(query: Record<string, string>) {
+      const request = createRequest(undefined, query);
       const response = await GET(request);
-      const data = (await response.json()) as Record<
-        string,
-        { subject: string; room: string; season: string; open_time: string }[]
-      >;
+      const data = (await response.json()) as SyllabusData;
+      const allItems = Object.values(data).flat();
+      return { response, data, allItems };
+    }
 
-      for (const items of Object.values(data)) {
-        for (const item of items) {
-          expect(item.subject.toLowerCase()).toContain("プログラミング");
-        }
+    test("subject パラメータで部分一致フィルタリングができること", async () => {
+      const { allItems } = await fetchFilteredData({
+        subject: "プログラミング",
+      });
+
+      // テストの信頼性を高めるため、0件で素通りすることを防ぐ
+      expect(allItems.length).toBeGreaterThan(0);
+      for (const item of allItems) {
+        expect(item.subject.toLowerCase()).toContain("プログラミング");
       }
     });
 
     test("room パラメータで部分一致フィルタリングができること", async () => {
-      const request = createRequest(undefined, { room: "101" });
-      const response = await GET(request);
-      const data = (await response.json()) as Record<
-        string,
-        { subject: string; room: string; season: string; open_time: string }[]
-      >;
+      const { allItems } = await fetchFilteredData({ room: "室" }); // 実際のJSONに存在する教室名の一部にする
 
-      for (const items of Object.values(data)) {
-        for (const item of items) {
-          expect(item.room.toLowerCase()).toContain("101");
-        }
+      expect(allItems.length).toBeGreaterThan(0);
+      for (const item of allItems) {
+        expect(item.room.toLowerCase()).toContain("室");
       }
     });
 
     test("season パラメータで完全一致フィルタリングができること", async () => {
-      const request = createRequest(undefined, { season: "前期" });
-      const response = await GET(request);
-      const data = (await response.json()) as Record<
-        string,
-        { subject: string; room: string; season: string; open_time: string }[]
-      >;
+      const { allItems } = await fetchFilteredData({ season: "前期" });
 
-      for (const items of Object.values(data)) {
-        for (const item of items) {
-          expect(item.season).toBe("前期");
-        }
+      expect(allItems.length).toBeGreaterThan(0);
+      for (const item of allItems) {
+        expect(item.season).toBe("前期");
       }
     });
 
     test("該当データがない場合は空のオブジェクトが返ること", async () => {
-      const request = createRequest(undefined, { subject: "存在しない科目" });
-      const response = await GET(request);
-      const data = await response.json();
+      const { data } = await fetchFilteredData({ subject: "存在しない科目" });
       expect(data).toEqual({});
     });
   });

--- a/tests/api/fetch_syllabus.test.ts
+++ b/tests/api/fetch_syllabus.test.ts
@@ -209,5 +209,57 @@ describe("GET /api/fetch_syllabus", () => {
       const { data } = await fetchFilteredData({ subject: "存在しない科目" });
       expect(data).toEqual({});
     });
+
+    describe("フィルタリングと ETag の連動", () => {
+      test("検索条件が異なると ETag も異なること", async () => {
+        const { response: res1 } = await fetchFilteredData({
+          subject: "プログラミング",
+        });
+        const { response: res2 } = await fetchFilteredData({ subject: "数学" });
+
+        const etag1 = res1.headers.get("etag");
+        const etag2 = res2.headers.get("etag");
+
+        expect(etag1).not.toBeNull();
+        expect(etag2).not.toBeNull();
+        expect(etag1).not.toBe(etag2);
+      });
+
+      test("フィルタリング条件が同じなら、その ETag で 304 Not Modified が返ること", async () => {
+        const { response: firstResponse } = await fetchFilteredData({
+          subject: "プログラミング",
+        });
+        const etag = firstResponse.headers.get("etag") as string;
+
+        // 同じ検索条件で If-None-Match を付与
+        const conditionalRequest = createRequest(
+          { "if-none-match": etag },
+          { subject: "プログラミング" },
+        );
+        const conditionalResponse = await GET(conditionalRequest);
+
+        expect(conditionalResponse.status).toBe(304);
+        expect(await conditionalResponse.text()).toBe("");
+      });
+
+      test("異なるフィルタリング条件の ETag を送ると 200 OK が返り新しい ETag が取得できること", async () => {
+        const { response: firstResponse } = await fetchFilteredData({
+          subject: "プログラミング",
+        });
+        const etag = firstResponse.headers.get("etag") as string;
+
+        // 別の検索条件で、以前の ETag を If-None-Match に付与
+        const conditionalRequest = createRequest(
+          { "if-none-match": etag },
+          { subject: "数学" },
+        );
+        const conditionalResponse = await GET(conditionalRequest);
+
+        expect(conditionalResponse.status).toBe(200);
+        const newEtag = conditionalResponse.headers.get("etag");
+        expect(newEtag).not.toBeNull();
+        expect(newEtag).not.toBe(etag);
+      });
+    });
   });
 });

--- a/tests/api/fetch_syllabus.test.ts
+++ b/tests/api/fetch_syllabus.test.ts
@@ -18,8 +18,18 @@ const SyllabusItemSchema = z.object({
 const ResponseSchema = z.record(z.string(), z.array(SyllabusItemSchema));
 
 const BASE_URL = "http://localhost/api/fetch_syllabus";
-const createRequest = (headers?: HeadersInit): Request =>
-  new Request(BASE_URL, { headers });
+const createRequest = (
+  headers?: HeadersInit,
+  query?: Record<string, string>,
+): Request => {
+  const url = new URL(BASE_URL);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      url.searchParams.append(key, value);
+    }
+  }
+  return new Request(url.toString(), { headers });
+};
 
 describe("GET /api/fetch_syllabus", () => {
   describe("初回リクエスト（If-None-Match なし）", () => {
@@ -151,6 +161,60 @@ describe("GET /api/fetch_syllabus", () => {
       const secondEtag = secondResponse.headers.get("etag");
 
       expect(firstEtag).toBe(secondEtag);
+    });
+  });
+
+  describe("クエリパラメータによるフィルタリング", () => {
+    test("subject パラメータで部分一致フィルタリングができること", async () => {
+      const request = createRequest(undefined, { subject: "プログラミング" });
+      const response = await GET(request);
+      const data = (await response.json()) as Record<
+        string,
+        { subject: string; room: string; season: string; open_time: string }[]
+      >;
+
+      for (const items of Object.values(data)) {
+        for (const item of items) {
+          expect(item.subject.toLowerCase()).toContain("プログラミング");
+        }
+      }
+    });
+
+    test("room パラメータで部分一致フィルタリングができること", async () => {
+      const request = createRequest(undefined, { room: "101" });
+      const response = await GET(request);
+      const data = (await response.json()) as Record<
+        string,
+        { subject: string; room: string; season: string; open_time: string }[]
+      >;
+
+      for (const items of Object.values(data)) {
+        for (const item of items) {
+          expect(item.room.toLowerCase()).toContain("101");
+        }
+      }
+    });
+
+    test("season パラメータで完全一致フィルタリングができること", async () => {
+      const request = createRequest(undefined, { season: "前期" });
+      const response = await GET(request);
+      const data = (await response.json()) as Record<
+        string,
+        { subject: string; room: string; season: string; open_time: string }[]
+      >;
+
+      for (const items of Object.values(data)) {
+        for (const item of items) {
+          expect(item.season).toBe("前期");
+        }
+      }
+    });
+
+    test("該当データがない場合は空のオブジェクトが返ること", async () => {
+      const request = createRequest(undefined, { subject: "存在しない科目" });
+      const response = await GET(request);
+      const data = await response.json();
+      expect(data).toEqual({});
     });
   });
 });

--- a/tests/components/ApiExplorer.test.tsx
+++ b/tests/components/ApiExplorer.test.tsx
@@ -4,6 +4,8 @@ import userEvent from "@testing-library/user-event";
 import ApiExplorer from "../../app/_components/ApiExplorer";
 
 describe("ApiExplorer Component", () => {
+  let originalClipboard: Clipboard;
+
   const setupFetchMock = (
     mockFn?: (...args: Parameters<typeof fetch>) => Promise<Response>,
   ) => {
@@ -28,6 +30,7 @@ describe("ApiExplorer Component", () => {
 
   beforeEach(() => {
     mock.restore();
+    originalClipboard = navigator.clipboard;
   });
 
   afterEach(() => {
@@ -38,6 +41,13 @@ describe("ApiExplorer Component", () => {
     if (typeof fetchMock?.mockRestore === "function") {
       fetchMock.mockRestore();
     }
+
+    // Restore clipboard
+    Object.defineProperty(navigator, "clipboard", {
+      value: originalClipboard,
+      writable: true,
+      configurable: true,
+    });
   });
 
   it("renders correctly with default state", () => {

--- a/tests/components/ApiExplorer.test.tsx
+++ b/tests/components/ApiExplorer.test.tsx
@@ -109,6 +109,68 @@ describe("ApiExplorer Component", () => {
     });
   });
 
+  it("sends a request with query parameters when filters are filled", async () => {
+    const user = userEvent.setup();
+    const fetchMockFn = mock(async (...args: Parameters<typeof fetch>) => {
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: new Headers(),
+      });
+    });
+    globalThis.fetch = fetchMockFn as unknown as typeof globalThis.fetch;
+
+    render(<ApiExplorer />);
+
+    // Open try it panel
+    await user.click(screen.getByRole("button", { name: "Try it" }));
+
+    // Fill in filter inputs
+    const subjectInput = screen.getByLabelText("subject");
+    const roomInput = screen.getByLabelText("room");
+    const seasonInput = screen.getByLabelText("season");
+    const timeInput = screen.getByLabelText("open_time");
+
+    await user.type(subjectInput, "math");
+    await user.type(roomInput, "101");
+    // Leave season and time empty to verify they are omitted if empty
+
+    await user.click(screen.getByRole("button", { name: "Send Request" }));
+
+    await waitFor(() => {
+      expect(fetchMockFn).toHaveBeenCalled();
+    });
+
+    // Check the URL passed to fetch
+    const fetchArgs = fetchMockFn.mock.calls[0] as Parameters<typeof fetch>;
+    expect(fetchArgs[0]).toBe("/api/fetch_syllabus?subject=math&room=101");
+
+    // Add another parameter
+    await user.type(seasonInput, "fall");
+    await user.click(screen.getByRole("button", { name: "Send Request" }));
+
+    await waitFor(() => {
+      expect(fetchMockFn).toHaveBeenCalledTimes(2);
+    });
+
+    const fetchArgs2 = fetchMockFn.mock.calls[1] as Parameters<typeof fetch>;
+    expect(fetchArgs2[0]).toBe(
+      "/api/fetch_syllabus?subject=math&room=101&season=fall",
+    );
+
+    // Add yet another parameter
+    await user.type(timeInput, "月1");
+    await user.click(screen.getByRole("button", { name: "Send Request" }));
+
+    await waitFor(() => {
+      expect(fetchMockFn).toHaveBeenCalledTimes(3);
+    });
+
+    const fetchArgs3 = fetchMockFn.mock.calls[2] as Parameters<typeof fetch>;
+    expect(fetchArgs3[0]).toBe(
+      "/api/fetch_syllabus?subject=math&room=101&season=fall&open_time=%E6%9C%881",
+    );
+  });
+
   it("handles network errors", async () => {
     const user = userEvent.setup();
     setupFetchMock(async () => {

--- a/tests/components/ApiExplorer.test.tsx
+++ b/tests/components/ApiExplorer.test.tsx
@@ -4,8 +4,26 @@ import userEvent from "@testing-library/user-event";
 import ApiExplorer from "../../app/_components/ApiExplorer";
 
 describe("ApiExplorer Component", () => {
-  const setupFetchMock = (mockFn: () => Promise<Response>) => {
-    globalThis.fetch = mock(mockFn) as unknown as typeof globalThis.fetch;
+  const setupFetchMock = (
+    mockFn?: (...args: Parameters<typeof fetch>) => Promise<Response>,
+  ) => {
+    const defaultMockFn = async (..._args: Parameters<typeof fetch>) =>
+      new Response(JSON.stringify({}), { status: 200 });
+    const fetchMock = mock(mockFn || defaultMockFn);
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    return fetchMock;
+  };
+
+  const setupComponent = async () => {
+    const user = userEvent.setup();
+    render(<ApiExplorer />);
+    return { user };
+  };
+
+  const setupAndOpenPanel = async () => {
+    const setup = await setupComponent();
+    await setup.user.click(screen.getByRole("button", { name: "Try it" }));
+    return setup;
   };
 
   beforeEach(() => {
@@ -32,8 +50,7 @@ describe("ApiExplorer Component", () => {
   });
 
   it("toggles the try-it panel when clicking the Try it button", async () => {
-    const user = userEvent.setup();
-    render(<ApiExplorer />);
+    const { user } = await setupComponent();
 
     const toggleButton = screen.getByRole("button", { name: "Try it" });
 
@@ -49,7 +66,6 @@ describe("ApiExplorer Component", () => {
   });
 
   it("sends a request and displays the result", async () => {
-    const user = userEvent.setup();
     const mockResponse = {
       "Room A": [
         {
@@ -70,9 +86,8 @@ describe("ApiExplorer Component", () => {
       });
     });
 
-    render(<ApiExplorer />);
+    const { user } = await setupAndOpenPanel();
 
-    await user.click(screen.getByRole("button", { name: "Try it" }));
     await user.click(screen.getByRole("button", { name: "Send Request" }));
 
     await waitFor(() => {
@@ -86,7 +101,6 @@ describe("ApiExplorer Component", () => {
   });
 
   it("handles 304 Not Modified response correctly", async () => {
-    const user = userEvent.setup();
     setupFetchMock(async () => {
       return new Response(null, {
         status: 304,
@@ -96,9 +110,8 @@ describe("ApiExplorer Component", () => {
       });
     });
 
-    render(<ApiExplorer />);
+    const { user } = await setupAndOpenPanel();
 
-    await user.click(screen.getByRole("button", { name: "Try it" }));
     await user.click(screen.getByRole("button", { name: "Send Request" }));
 
     await waitFor(() => {
@@ -110,19 +123,9 @@ describe("ApiExplorer Component", () => {
   });
 
   it("sends a request with query parameters when filters are filled", async () => {
-    const user = userEvent.setup();
-    const fetchMockFn = mock(async (...args: Parameters<typeof fetch>) => {
-      return new Response(JSON.stringify({}), {
-        status: 200,
-        headers: new Headers(),
-      });
-    });
-    globalThis.fetch = fetchMockFn as unknown as typeof globalThis.fetch;
+    const fetchMockFn = setupFetchMock();
 
-    render(<ApiExplorer />);
-
-    // Open try it panel
-    await user.click(screen.getByRole("button", { name: "Try it" }));
+    const { user } = await setupAndOpenPanel();
 
     // Fill in filter inputs
     const subjectInput = screen.getByLabelText("subject");
@@ -141,8 +144,9 @@ describe("ApiExplorer Component", () => {
     });
 
     // Check the URL passed to fetch
-    const fetchArgs = fetchMockFn.mock.calls[0] as Parameters<typeof fetch>;
-    expect(fetchArgs[0]).toBe("/api/fetch_syllabus?subject=math&room=101");
+    expect(fetchMockFn.mock.calls[0][0]).toBe(
+      "/api/fetch_syllabus?subject=math&room=101",
+    );
 
     // Add another parameter
     await user.type(seasonInput, "fall");
@@ -152,8 +156,7 @@ describe("ApiExplorer Component", () => {
       expect(fetchMockFn).toHaveBeenCalledTimes(2);
     });
 
-    const fetchArgs2 = fetchMockFn.mock.calls[1] as Parameters<typeof fetch>;
-    expect(fetchArgs2[0]).toBe(
+    expect(fetchMockFn.mock.calls[1][0]).toBe(
       "/api/fetch_syllabus?subject=math&room=101&season=fall",
     );
 
@@ -165,26 +168,95 @@ describe("ApiExplorer Component", () => {
       expect(fetchMockFn).toHaveBeenCalledTimes(3);
     });
 
-    const fetchArgs3 = fetchMockFn.mock.calls[2] as Parameters<typeof fetch>;
-    expect(fetchArgs3[0]).toBe(
+    expect(fetchMockFn.mock.calls[2][0]).toBe(
       "/api/fetch_syllabus?subject=math&room=101&season=fall&open_time=%E6%9C%881",
     );
   });
 
   it("handles network errors", async () => {
-    const user = userEvent.setup();
     setupFetchMock(async () => {
       throw new Error("Network Error");
     });
 
-    render(<ApiExplorer />);
+    const { user } = await setupAndOpenPanel();
 
-    await user.click(screen.getByRole("button", { name: "Try it" }));
     await user.click(screen.getByRole("button", { name: "Send Request" }));
 
     await waitFor(() => {
       expect(screen.getByText("エラー:")).toBeDefined();
       expect(screen.getByText(/Network Error/)).toBeDefined();
     });
+  });
+
+  it("copies the request URL to the clipboard and shows feedback", async () => {
+    const { user } = await setupAndOpenPanel();
+
+    // Mock navigator.clipboard
+    const writeTextMock = mock(async (..._args: [string]) => {});
+    Object.defineProperty(navigator, "clipboard", {
+      value: {
+        writeText: writeTextMock,
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    // Find and click the copy button
+    const copyButton = screen.getByRole("button", { name: "Copy" });
+    await user.click(copyButton);
+
+    // Verify clipboard was called with the correct base URL
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledTimes(1);
+    });
+    expect(writeTextMock.mock.calls[0][0]).toMatch(/\/api\/fetch_syllabus$/);
+
+    // Verify feedback text changes to "Copied!"
+    expect(screen.getByRole("button", { name: "Copied!" })).toBeDefined();
+
+    // Type into a filter to change the URL
+    const subjectInput = screen.getByLabelText("subject");
+    await user.type(subjectInput, "math");
+
+    // Click copy again on the updated URL
+    // Wait for "Copy" to come back or click the same button instance since its label changed
+    // For simplicity, click the "Copied!" button which will still trigger the updated state copy,
+    // though the 2000ms timeout might execute during this text.
+    await user.click(copyButton);
+
+    await waitFor(() => {
+      expect(writeTextMock).toHaveBeenCalledTimes(2);
+    });
+
+    // Ensure the new URL includes the query param
+    expect(writeTextMock.mock.calls[1][0]).toMatch(
+      /\/api\/fetch_syllabus\?subject=math$/,
+    );
+  });
+
+  it("updates the displayed request URL correctly when query parameters are changed", async () => {
+    const { user } = await setupAndOpenPanel();
+
+    // Target the URL preview
+    const urlPreview = screen.getByTestId("request-url-preview");
+
+    // Initial state
+    expect(urlPreview.textContent).toBe("/api/fetch_syllabus");
+
+    // Type in subject
+    const subjectInput = screen.getByLabelText("subject");
+    await user.type(subjectInput, "math");
+    expect(urlPreview.textContent).toBe("/api/fetch_syllabus?subject=math");
+
+    // Type in room
+    const roomInput = screen.getByLabelText("room");
+    await user.type(roomInput, "101");
+    expect(urlPreview.textContent).toBe(
+      "/api/fetch_syllabus?subject=math&room=101",
+    );
+
+    // Clear subject parameter
+    await user.clear(subjectInput);
+    expect(urlPreview.textContent).toBe("/api/fetch_syllabus?room=101");
   });
 });

--- a/tests/utils/formatters.test.ts
+++ b/tests/utils/formatters.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatJsonBody,
+  getStatusBadgeClass,
+  parseSubject,
+} from "../../app/_utils/formatters";
+
+describe("formatters", () => {
+  describe("parseSubject", () => {
+    it("should split subject code and name separated by ' : '", () => {
+      const result = parseSubject("1234 : Introduction to Computer Science");
+      expect(result.code).toBe("1234");
+      expect(result.name).toBe("Introduction to Computer Science");
+    });
+
+    it("should return empty code if separator is missing", () => {
+      const result = parseSubject("Introduction to Computer Science");
+      expect(result.code).toBe("");
+      expect(result.name).toBe("Introduction to Computer Science");
+    });
+  });
+
+  describe("formatJsonBody", () => {
+    it("should format valid JSON and add preview comment", () => {
+      const sample = {
+        RoomA: [1, 2],
+        RoomB: [3, 4],
+        RoomC: [5, 6],
+        RoomD: [7, 8],
+      };
+
+      const result = formatJsonBody(JSON.stringify(sample), 2, "rooms");
+
+      expect(result).toContain("// Showing 2 of 4 rooms");
+      expect(result).toContain('"RoomA"');
+      expect(result).toContain('"RoomB"');
+      expect(result).not.toContain('"RoomC"');
+    });
+
+    it("should return raw string if json is invalid", () => {
+      const result = formatJsonBody("not valid json", 2, "rooms");
+      expect(result).toBe("not valid json");
+    });
+  });
+
+  describe("getStatusBadgeClass", () => {
+    it("should return emerald class for 2xx status", () => {
+      expect(getStatusBadgeClass(200)).toContain("emerald");
+      expect(getStatusBadgeClass(299)).toContain("emerald");
+    });
+
+    it("should return blue class for 3xx status", () => {
+      expect(getStatusBadgeClass(304)).toContain("blue");
+      expect(getStatusBadgeClass(399)).toContain("blue");
+    });
+
+    it("should return red class for 4xx and 5xx status", () => {
+      expect(getStatusBadgeClass(404)).toContain("red");
+      expect(getStatusBadgeClass(500)).toContain("red");
+    });
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * シラバスAPIにクエリパラメータによるフィルタリングを追加（科目・教室は部分一致・大文字小文字無視、学期・開始時刻は完全一致）。
  * APIドキュメントと「Try it」パネルにクエリ入力欄、リクエストURL表示・コピー機能を追加。
* **改善**
  * フィルタ条件に応じたレスポンスとETagを返すようにし、同条件での再取得は304で応答され効率化。
  * ドキュメントのレスポンスプレビューとステータス表示を見やすく改善。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->